### PR TITLE
Remove invalid security grant from ABC framework

### DIFF
--- a/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
+++ b/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
@@ -1004,7 +1004,7 @@
     "subtype" : "",
     "removeOthers" : false,
     "failIfNotFound": false,
-    "permissions" : [ "Create Components", "Create Components From Template", "Delete", "Edit Basic Settings", "Manage Configuration Templates", "Manage Processes", "Manage Properties", "Manage Teams", "Manage Versions", "View Components" ]
+    "permissions" : [ "Create Components", "Create Components From Template", "Delete", "Edit Basic Settings", "Edit Components", "Manage Configuration Templates", "Manage Processes", "Manage Properties", "Manage Teams", "Manage Versions", "View Components" ]
   }, {
     "action" : "UcdAddRolePermissions",
     "role" : "ABC Superuser",

--- a/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
+++ b/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
@@ -1003,6 +1003,7 @@
     "type" : "Component",
     "subtype" : "",
     "removeOthers" : false,
+    "failIfNotFound": false,
     "permissions" : [ "Create Components", "Create Components From Template", "Delete", "Edit Basic Settings", "Manage Configuration Templates", "Manage Processes", "Manage Properties", "Manage Teams", "Manage Versions", "View Components" ]
   }, {
     "action" : "UcdAddRolePermissions",

--- a/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
+++ b/Development/ABC-UCADF/UCADF-Package/Actions/AbcUcAdfSecurity.json
@@ -1003,7 +1003,7 @@
     "type" : "Component",
     "subtype" : "",
     "removeOthers" : false,
-    "permissions" : [ "Create Components", "Create Components From Template", "Delete", "Edit Basic Settings", "Edit Components", "Manage Configuration Templates", "Manage Processes", "Manage Properties", "Manage Teams", "Manage Versions", "View Components" ]
+    "permissions" : [ "Create Components", "Create Components From Template", "Delete", "Edit Basic Settings", "Manage Configuration Templates", "Manage Processes", "Manage Properties", "Manage Teams", "Manage Versions", "View Components" ]
   }, {
     "action" : "UcdAddRolePermissions",
     "role" : "ABC Superuser",


### PR DESCRIPTION
"Edit Components" does not exist in 7.0.5.2